### PR TITLE
update lmdb dependency & set build for Ubuntu 20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@grpc/proto-loader": "^0.7.2",
         "dotenv": "^16.0.2",
         "enf-eosjs": "^23.0.0-rc4",
-        "lmdb": "^2.6.0-alpha7",
+        "lmdb": "^2.7.3",
         "protobufjs": "^6.10.2"
       },
       "bin": {
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.6.8.tgz",
-      "integrity": "sha512-u3BSAWCiyN8DZnXx4HdQjFTD2mlAnRHCmtgjQY7RwH99bFgZQzGpqvtM4TNh5bLuInxovyilI3qNmqUBEqbgtg==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.7.2.tgz",
+      "integrity": "sha512-JSOnckSaJbLxvvgOihVzop52r/QWTptScJ17IhQNny2kB/eKrFstR252FEcuORRPbDIR6L/plQJV3GvvjPjJhw==",
       "cpu": [
         "arm64"
       ],
@@ -189,16 +189,136 @@
         "darwin"
       ]
     },
+    "node_modules/@lmdb/lmdb-darwin-x64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.7.2.tgz",
+      "integrity": "sha512-b7m6/h2GyAxCB0dIxOdRVHFKzXvk65s1NpusCl5G7EDKLBnVWpB9TN/BtvNlyyLu3LZ4kdytpqbHGb0WvKdvNg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-arm": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.7.2.tgz",
+      "integrity": "sha512-JCbuWWDZ/NPCzVEe3wmKR516qbKjtu7nD2xsVuIPlJbSOUcc6sciu0MsPEulpSg1DgXGbh09EoJiKfd8BDaBhQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-arm64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.7.2.tgz",
+      "integrity": "sha512-1uhBOZLMD6BNT8jdt6b+yUbXnnLXFFV2mwy2o9aAYsUHtCRccUcorqYTAPq+14d7/LpT1gzMNpOzdrO4qnIMBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-x64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.7.2.tgz",
+      "integrity": "sha512-sQ7sl7aLEtC9eGrLEhl6m73+FC0upKN/nEp+WmrYtxa1mSHggXzEvHvCkywNtFu3NcGTT0iRH30ylT93t+dgrg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-win32-x64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.7.2.tgz",
+      "integrity": "sha512-beC/L5v1ByVbwILbnnN1xJVlAxfNAm0/HeYgf8h9SuQtdxo5Whnv03eWZ+Sr8Lo2eicnRKlJGzWts+/99kf08w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.1.2.tgz",
-      "integrity": "sha512-TyVLn3S/+ikMDsh0gbKv2YydKClN8HaJDDpONlaZR+LVJmsxLFUgA+O7zu59h9+f9gX1aj/ahw9wqa6rosmrYQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.2.0.tgz",
+      "integrity": "sha512-Z9LFPzfoJi4mflGWV+rv7o7ZbMU5oAU9VmzCgL240KnqDW65Y2HFCT3MW06/ITJSnbVLacmcEJA8phywK7JinQ==",
       "cpu": [
         "arm64"
       ],
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.2.0.tgz",
+      "integrity": "sha512-vq0tT8sjZsy4JdSqmadWVw6f66UXqUCabLmUVHZwUFzMgtgoIIQjT4VVRHKvlof3P/dMCkbMJ5hB1oJ9OWHaaw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.2.0.tgz",
+      "integrity": "sha512-SaJ3Qq4lX9Syd2xEo9u3qPxi/OB+5JO/ngJKK97XDpa1C587H9EWYO6KD8995DAjSinWvdHKRrCOXVUC5fvGOg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.2.0.tgz",
+      "integrity": "sha512-hlxxLdRmPyq16QCutUtP8Tm6RDWcyaLsRssaHROatgnkOxdleMTgetf9JsdncL8vLh7FVy/RN9i3XR5dnb9cRA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.2.0.tgz",
+      "integrity": "sha512-94y5PJrSOqUNcFKmOl7z319FelCLAE0rz/jPCWS+UtdMZvpa4jrQd+cJPQCLp2Fes1yAW/YUQj/Di6YVT3c3Iw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.2.0.tgz",
+      "integrity": "sha512-XrC0JzsqQSvOyM3t04FMLO6z5gCuhPE6k4FXuLK5xf52ZbdvcFe1yBmo7meCew9B8G2f0T9iu9t3kfTYRYROgA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1058,14 +1178,14 @@
       }
     },
     "node_modules/lmdb": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.6.8.tgz",
-      "integrity": "sha512-Vn+o5gFYTE39twmt9gVSDJi8mrWbnkDongSuYdGxhHDHFGX4ct2ITQWMp5THeoEcsQsNK4KhALjW1Hx83x7WGw==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.7.3.tgz",
+      "integrity": "sha512-uC+Ek7FeIbpc+foJXl1AkFZCcXBfha6W/PkB5inMyc5gMZSnnhP89W3a+LuG2L8rZeGSvTEdv4spFMempd8DiA==",
       "hasInstallScript": true,
       "dependencies": {
-        "msgpackr": "1.7.2",
+        "msgpackr": "1.8.1",
         "node-addon-api": "^4.3.0",
-        "node-gyp-build-optional-packages": "5.0.3",
+        "node-gyp-build-optional-packages": "5.0.5",
         "ordered-binary": "^1.4.0",
         "weak-lru-cache": "^1.2.2"
       },
@@ -1073,12 +1193,12 @@
         "download-lmdb-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@lmdb/lmdb-darwin-arm64": "2.6.8",
-        "@lmdb/lmdb-darwin-x64": "2.6.8",
-        "@lmdb/lmdb-linux-arm": "2.6.8",
-        "@lmdb/lmdb-linux-arm64": "2.6.8",
-        "@lmdb/lmdb-linux-x64": "2.6.8",
-        "@lmdb/lmdb-win32-x64": "2.6.8"
+        "@lmdb/lmdb-darwin-arm64": "2.7.2",
+        "@lmdb/lmdb-darwin-x64": "2.7.2",
+        "@lmdb/lmdb-linux-arm": "2.7.2",
+        "@lmdb/lmdb-linux-arm64": "2.7.2",
+        "@lmdb/lmdb-linux-x64": "2.7.2",
+        "@lmdb/lmdb-win32-x64": "2.7.2"
       }
     },
     "node_modules/lodash.camelcase": {
@@ -1168,17 +1288,17 @@
       "dev": true
     },
     "node_modules/msgpackr": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.7.2.tgz",
-      "integrity": "sha512-mWScyHTtG6TjivXX9vfIy2nBtRupaiAj0HQ2mtmpmYujAmqZmaaEVPaSZ1NKLMvicaMLFzEaMk0ManxMRg8rMQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.1.tgz",
+      "integrity": "sha512-05fT4J8ZqjYlR4QcRDIhLCYKUOHXk7C/xa62GzMKj74l3up9k2QZ3LgFc6qWdsPHl91QA2WLWqWc8b8t7GLNNw==",
       "optionalDependencies": {
-        "msgpackr-extract": "^2.1.2"
+        "msgpackr-extract": "^2.2.0"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.1.2.tgz",
-      "integrity": "sha512-cmrmERQFb19NX2JABOGtrKdHMyI6RUyceaPBQ2iRz9GnDkjBWFjNJC0jyyoOfZl2U/LZE3tQCCQc4dlRyA8mcA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.2.0.tgz",
+      "integrity": "sha512-0YcvWSv7ZOGl9Od6Y5iJ3XnPww8O7WLcpYMDwX+PAA/uXLDtyw94PJv9GLQV/nnp3cWlDhMoyKZIQLrx33sWog==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -1188,12 +1308,23 @@
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.1.2"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.2.0"
+      }
+    },
+    "node_modules/msgpackr-extract/node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+      "optional": true,
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/multistream": {
@@ -1283,9 +1414,9 @@
       }
     },
     "node_modules/node-gyp-build-optional-packages": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
-      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.5.tgz",
+      "integrity": "sha512-Pij9VQ5eqQi/8T2Hq/KJMJAnyAOXx4velbT/LgV1boQjv+xH4E1zEmlOP1c16HQtkmCaXI7HkLLv7iIb4umAEg==",
       "bin": {
         "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-optional-packages-optional": "optional.js",
@@ -2068,15 +2199,75 @@
       }
     },
     "@lmdb/lmdb-darwin-arm64": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.6.8.tgz",
-      "integrity": "sha512-u3BSAWCiyN8DZnXx4HdQjFTD2mlAnRHCmtgjQY7RwH99bFgZQzGpqvtM4TNh5bLuInxovyilI3qNmqUBEqbgtg==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.7.2.tgz",
+      "integrity": "sha512-JSOnckSaJbLxvvgOihVzop52r/QWTptScJ17IhQNny2kB/eKrFstR252FEcuORRPbDIR6L/plQJV3GvvjPjJhw==",
+      "optional": true
+    },
+    "@lmdb/lmdb-darwin-x64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.7.2.tgz",
+      "integrity": "sha512-b7m6/h2GyAxCB0dIxOdRVHFKzXvk65s1NpusCl5G7EDKLBnVWpB9TN/BtvNlyyLu3LZ4kdytpqbHGb0WvKdvNg==",
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-arm": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.7.2.tgz",
+      "integrity": "sha512-JCbuWWDZ/NPCzVEe3wmKR516qbKjtu7nD2xsVuIPlJbSOUcc6sciu0MsPEulpSg1DgXGbh09EoJiKfd8BDaBhQ==",
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-arm64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.7.2.tgz",
+      "integrity": "sha512-1uhBOZLMD6BNT8jdt6b+yUbXnnLXFFV2mwy2o9aAYsUHtCRccUcorqYTAPq+14d7/LpT1gzMNpOzdrO4qnIMBw==",
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-x64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.7.2.tgz",
+      "integrity": "sha512-sQ7sl7aLEtC9eGrLEhl6m73+FC0upKN/nEp+WmrYtxa1mSHggXzEvHvCkywNtFu3NcGTT0iRH30ylT93t+dgrg==",
+      "optional": true
+    },
+    "@lmdb/lmdb-win32-x64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.7.2.tgz",
+      "integrity": "sha512-beC/L5v1ByVbwILbnnN1xJVlAxfNAm0/HeYgf8h9SuQtdxo5Whnv03eWZ+Sr8Lo2eicnRKlJGzWts+/99kf08w==",
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.1.2.tgz",
-      "integrity": "sha512-TyVLn3S/+ikMDsh0gbKv2YydKClN8HaJDDpONlaZR+LVJmsxLFUgA+O7zu59h9+f9gX1aj/ahw9wqa6rosmrYQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.2.0.tgz",
+      "integrity": "sha512-Z9LFPzfoJi4mflGWV+rv7o7ZbMU5oAU9VmzCgL240KnqDW65Y2HFCT3MW06/ITJSnbVLacmcEJA8phywK7JinQ==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.2.0.tgz",
+      "integrity": "sha512-vq0tT8sjZsy4JdSqmadWVw6f66UXqUCabLmUVHZwUFzMgtgoIIQjT4VVRHKvlof3P/dMCkbMJ5hB1oJ9OWHaaw==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.2.0.tgz",
+      "integrity": "sha512-SaJ3Qq4lX9Syd2xEo9u3qPxi/OB+5JO/ngJKK97XDpa1C587H9EWYO6KD8995DAjSinWvdHKRrCOXVUC5fvGOg==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.2.0.tgz",
+      "integrity": "sha512-hlxxLdRmPyq16QCutUtP8Tm6RDWcyaLsRssaHROatgnkOxdleMTgetf9JsdncL8vLh7FVy/RN9i3XR5dnb9cRA==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.2.0.tgz",
+      "integrity": "sha512-94y5PJrSOqUNcFKmOl7z319FelCLAE0rz/jPCWS+UtdMZvpa4jrQd+cJPQCLp2Fes1yAW/YUQj/Di6YVT3c3Iw==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.2.0.tgz",
+      "integrity": "sha512-XrC0JzsqQSvOyM3t04FMLO6z5gCuhPE6k4FXuLK5xf52ZbdvcFe1yBmo7meCew9B8G2f0T9iu9t3kfTYRYROgA==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -2749,19 +2940,19 @@
       }
     },
     "lmdb": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.6.8.tgz",
-      "integrity": "sha512-Vn+o5gFYTE39twmt9gVSDJi8mrWbnkDongSuYdGxhHDHFGX4ct2ITQWMp5THeoEcsQsNK4KhALjW1Hx83x7WGw==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.7.3.tgz",
+      "integrity": "sha512-uC+Ek7FeIbpc+foJXl1AkFZCcXBfha6W/PkB5inMyc5gMZSnnhP89W3a+LuG2L8rZeGSvTEdv4spFMempd8DiA==",
       "requires": {
-        "@lmdb/lmdb-darwin-arm64": "2.6.8",
-        "@lmdb/lmdb-darwin-x64": "2.6.8",
-        "@lmdb/lmdb-linux-arm": "2.6.8",
-        "@lmdb/lmdb-linux-arm64": "2.6.8",
-        "@lmdb/lmdb-linux-x64": "2.6.8",
-        "@lmdb/lmdb-win32-x64": "2.6.8",
-        "msgpackr": "1.7.2",
+        "@lmdb/lmdb-darwin-arm64": "2.7.2",
+        "@lmdb/lmdb-darwin-x64": "2.7.2",
+        "@lmdb/lmdb-linux-arm": "2.7.2",
+        "@lmdb/lmdb-linux-arm64": "2.7.2",
+        "@lmdb/lmdb-linux-x64": "2.7.2",
+        "@lmdb/lmdb-win32-x64": "2.7.2",
+        "msgpackr": "1.8.1",
         "node-addon-api": "^4.3.0",
-        "node-gyp-build-optional-packages": "5.0.3",
+        "node-gyp-build-optional-packages": "5.0.5",
         "ordered-binary": "^1.4.0",
         "weak-lru-cache": "^1.2.2"
       }
@@ -2835,26 +3026,34 @@
       "dev": true
     },
     "msgpackr": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.7.2.tgz",
-      "integrity": "sha512-mWScyHTtG6TjivXX9vfIy2nBtRupaiAj0HQ2mtmpmYujAmqZmaaEVPaSZ1NKLMvicaMLFzEaMk0ManxMRg8rMQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.1.tgz",
+      "integrity": "sha512-05fT4J8ZqjYlR4QcRDIhLCYKUOHXk7C/xa62GzMKj74l3up9k2QZ3LgFc6qWdsPHl91QA2WLWqWc8b8t7GLNNw==",
       "requires": {
-        "msgpackr-extract": "^2.1.2"
+        "msgpackr-extract": "^2.2.0"
       }
     },
     "msgpackr-extract": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.1.2.tgz",
-      "integrity": "sha512-cmrmERQFb19NX2JABOGtrKdHMyI6RUyceaPBQ2iRz9GnDkjBWFjNJC0jyyoOfZl2U/LZE3tQCCQc4dlRyA8mcA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.2.0.tgz",
+      "integrity": "sha512-0YcvWSv7ZOGl9Od6Y5iJ3XnPww8O7WLcpYMDwX+PAA/uXLDtyw94PJv9GLQV/nnp3cWlDhMoyKZIQLrx33sWog==",
       "optional": true,
       "requires": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.1.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.2.0",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.2.0",
         "node-gyp-build-optional-packages": "5.0.3"
+      },
+      "dependencies": {
+        "node-gyp-build-optional-packages": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+          "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+          "optional": true
+        }
       }
     },
     "multistream": {
@@ -2917,9 +3116,9 @@
       }
     },
     "node-gyp-build-optional-packages": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
-      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA=="
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.5.tgz",
+      "integrity": "sha512-Pij9VQ5eqQi/8T2Hq/KJMJAnyAOXx4velbT/LgV1boQjv+xH4E1zEmlOP1c16HQtkmCaXI7HkLLv7iIb4umAEg=="
     },
     "npmlog": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@grpc/proto-loader": "^0.7.2",
     "dotenv": "^16.0.2",
     "enf-eosjs": "^23.0.0-rc4",
-    "lmdb": "^2.6.0-alpha7",
+    "lmdb": "^2.7.3",
     "protobufjs": "^6.10.2"
   },
   "devDependencies": {
@@ -24,6 +24,7 @@
   "pkg": {
     "assets": [
       "node_modules/lmdb",
+      "node_modules/@lmdb",
       "proto/**/*.proto"
     ]
   }


### PR DESCRIPTION
- Change to Ubuntu 20.04 build
- Update `lmdb` dependency
- Include `@lmdb` to pre-built binaries